### PR TITLE
update JsonSerializable to be compatible with interface

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -525,6 +525,9 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
+    /**
+     * @return mixed
+     */
     public function jsonSerialize()
     {
         return $this->__toString();


### PR DESCRIPTION
after update to php 8.1 I got this error: `Deprecated: Return type of GuzzleHttp\Psr7\Uri::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/guzzlehttp/psr7/src/Uri.php on line 528
`